### PR TITLE
Add badge for hexdocs and hex.pm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DateTimeParser
 
+[![Hex.pm Version](http://img.shields.io/hexpm/v/date_time_parser.svg)](https://hex.pm/packages/date_time_parser)
+[![Hex docs](http://img.shields.io/badge/hex.pm-docs-blue.svg?style=flat)](https://hexdocs.pm/date_time_parser)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](./CODE_OF_CONDUCT.md)
 


### PR DESCRIPTION
This adds badges to 

- link to hexdocs again
- show which version is published at hex.pm. helpful in case master is a different version. 

![image](https://user-images.githubusercontent.com/643967/63618824-ffefb800-c5ba-11e9-9287-f0485333037a.png)
