### PR TITLE
Refactor and add Roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.4
+
+- Refactor
+- Support subsecond parsing to 24 digits (yoctoseconds) [thanks @myfreeweb]
+
 ## 0.1.3
 
 - Support parsing Unix epoch times from strings

--- a/README.md
+++ b/README.md
@@ -18,12 +18,41 @@ vocal month (eg, `"Jan"`).
 If the string is 10-11 digits with optional precision, then we'll try to parse
 it as a Unix epoch timestamp.
 
+## Planned Breaking Changes
+
+* `parse_datetime` currently assumes `00:00:00` time if it cannot be determined.
+    This will likely change in a future version because it's better to have no
+    information than have wrong information. If you want to assume `00:00:00`,
+    that's fine, but this library shouldn't assume it for you, or at least make
+    it an option.
+* `parse_datetime` currently defaults to converting to UTC when the timezone is
+    known. This default may change to keep the original timezone information.
+    This will help for future timestamps since timezone rules change; converting
+    to UTC too early may use rules that become outdated by the time the
+    timestamp arrives. The option to convert to UTC will remain, but may not be
+    default.
+* Introduce `parse` to parse as much as it can, but return any of the structs,
+    `%DateTime{}` `%NaiveDateTime{}` `%Date{}` or `%Time{}`. It would be up to
+    you to match on what the result is and do what you will. If you know you
+    want the one specific struct, then you can continue to use the more-specific
+    functions like `parse_date`.
+
+## Required reading
+
+* [Elixir DateTime docs](https://hexdocs.pm/elixir/DateTime.html)
+* [Elixir NaiveDateTime docs](https://hexdocs.pm/elixir/NaiveDateTime.html)
+* [Elixir Date docs](https://hexdocs.pm/elixir/Date.html)
+* [Elixir Time docs](https://hexdocs.pm/elixir/Time.html)
+* [Elixir Calendar docs](https://hexdocs.pm/elixir/Calendar.html)
+* [How to save datetimes for future events (when UTC is not the right answer)](http://www.creativedeletion.com/2015/03/19/persisting_future_datetimes.html)
+  * tldr: rules change, so don't convert to UTC too early. The future might
+      change the timezone conversion rules.
+
 ## Documentation
 
 [Online Documentation](https://hexdocs.pm/date_time_parser)
 
 ## Examples
-
 
 ```elixir
 iex> DateTimeParser.parse_datetime("19 September 2018 08:15:22 AM")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ first. All other cases will use the international format `ymd`. Sometimes, if
 the conditions are right, it can even parse `dmy` with dashes if the month is a
 vocal month (eg, `"Jan"`).
 
+If the string is 10-11 digits with optional precision, then we'll try to parse
+it as a Unix epoch timestamp.
+
 ## Documentation
 
 [Online Documentation](https://hexdocs.pm/date_time_parser)

--- a/lib/combinators/time.ex
+++ b/lib/combinators/time.ex
@@ -25,7 +25,7 @@ defmodule DateTimeParser.Combinators.Time do
     |> ascii_char()
     |> times(min: 1, max: 24)
     |> tag(:microsecond)
-    |> label("numeric microsecond up to 24 digits")
+    |> label("numeric subsecond up to 24 digits")
   end
 
   def second_or_minute do

--- a/lib/date.ex
+++ b/lib/date.ex
@@ -3,6 +3,7 @@ defmodule DateTimeParser.Date do
 
   import NimbleParsec
   import DateTimeParser.Combinators.Date
+  import DateTimeParser.Formatters, only: [format_token: 2]
 
   defparsec(
     :parse,
@@ -17,4 +18,12 @@ defmodule DateTimeParser.Date do
     |> optional()
     |> concat(us_date())
   )
+
+  def from_tokens(tokens) do
+    Date.new(
+      format_token(tokens, :year) || 0,
+      format_token(tokens, :month) || 0,
+      format_token(tokens, :day) || 0
+    )
+  end
 end

--- a/lib/date.ex
+++ b/lib/date.ex
@@ -21,9 +21,9 @@ defmodule DateTimeParser.Date do
 
   def from_tokens(tokens) do
     Date.new(
-      format_token(tokens, :year) || 0,
-      format_token(tokens, :month) || 0,
-      format_token(tokens, :day) || 0
+      format_token(tokens, :year),
+      format_token(tokens, :month),
+      format_token(tokens, :day)
     )
   end
 end

--- a/lib/date_time.ex
+++ b/lib/date_time.ex
@@ -4,6 +4,7 @@ defmodule DateTimeParser.DateTime do
   import NimbleParsec
   import DateTimeParser.Combinators.Date
   import DateTimeParser.Combinators.DateTime
+  import DateTimeParser.Formatters, only: [format_token: 2, clean: 1]
 
   defparsec(
     :parse,
@@ -26,4 +27,40 @@ defmodule DateTimeParser.DateTime do
       us_date()
     ])
   )
+
+  def from_tokens(tokens) do
+    Map.merge(
+      NaiveDateTime.utc_now(),
+      clean(%{
+        year: format_token(tokens, :year),
+        month: format_token(tokens, :month),
+        day: format_token(tokens, :day),
+        hour: format_token(tokens, :hour) || 0,
+        minute: format_token(tokens, :minute) || 0,
+        second: format_token(tokens, :second) || 0,
+        microsecond: format_token(tokens, :microsecond) || {0, 0}
+      })
+    )
+  end
+
+  def timezone_from_tokens(tokens) do
+    with zone <- format_token(tokens, :zone_abbr),
+         offset <- format_token(tokens, :utc_offset),
+         true <- Enum.any?([zone, offset]) do
+      Timex.Timezone.get(offset || zone)
+    end
+  end
+
+  def from_naive_datetime_and_timezone(naive_datetime, nil), do: naive_datetime
+
+  def from_naive_datetime_and_timezone(naive_datetime, timezone_info) do
+    naive_datetime
+    |> DateTime.from_naive!("Etc/UTC")
+    |> Map.merge(%{
+      std_offset: timezone_info.offset_std,
+      utc_offset: timezone_info.offset_utc,
+      zone_abbr: timezone_info.abbreviation,
+      time_zone: timezone_info.full_name
+    })
+  end
 end

--- a/lib/date_time_parser.ex
+++ b/lib/date_time_parser.ex
@@ -1,16 +1,16 @@
 defmodule DateTimeParser do
   @moduledoc """
-  DateTimeParser is a tokenizer for strings that attempts to parse into a
-  `DateTime`, `NaiveDateTime` if timezone is not determined, `Date`, or `Time`.
+  DateTimeParser is a tokenizer for strings that attempts to parse into a `DateTime`,
+  `NaiveDateTime` if timezone is not determined, `Date`, or `Time`.
 
-  The biggest ambiguity between datetime formats is whether it's `ymd` (year month
-  day), `mdy` (month day year), or `dmy` (day month year); this is resolved by
-  checking if there are slashes or dashes. If slashes, then it will try `dmy`
-  first. All other cases will use the international format `ymd`. Sometimes, if
-  the conditions are right, it can even parse `dmy` with dashes if the month is a
-  vocal month (eg, `"Jan"`).
+  The biggest ambiguity between datetime formats is whether it's `ymd` (year month day), `mdy`
+  (month day year), or `dmy` (day month year); this is resolved by checking if there are slashes or
+  dashes. If slashes, then it will try `dmy` first. All other cases will use the international
+  format `ymd`. Sometimes, if the conditions are right, it can even parse `dmy` with dashes if the
+  month is a vocal month (eg, `"Jan"`).
 
-  If the string starts with 10 digits, then we'll try to parse it as a Unix epoch timestamp.
+  If the string is 10-11 digits with optional precision, then we'll try to parse it as a Unix epoch
+  timestamp.
 
   ## Examples
 
@@ -72,20 +72,18 @@ defmodule DateTimeParser do
     If there's a timezone detected in the string, then attempt to convert to UTC timezone. This is
     helpful for storing in databases with Ecto.
   """
-  @epoch_regex ~r|\A(?<!\d)\d{10}\.?\d{0,10}\z|
+
+  import DateTimeParser.Formatters
+  alias DateTimeParser.Epoch
+
+  @epoch_regex ~r|\A\d{10,11}(?:\.\d{1,10})?\z|
   @spec parse_datetime(String.t() | nil, Keyword.t()) ::
           {:ok, DateTime.t() | NaiveDateTime.t()} | {:error, String.t()}
   def parse_datetime(string, opts \\ [])
 
   def parse_datetime(string, opts) when is_binary(string) do
-    parser =
-      cond do
-        String.contains?(string, "/") -> &DateTimeParser.DateTime.parse_us/1
-        Regex.match?(@epoch_regex, string) -> &DateTimeParser.Epoch.parse/1
-        true -> &DateTimeParser.DateTime.parse/1
-      end
-
-    with {:ok, tokens, _, _, _, _} <- string |> clean() |> parser.(),
+    with string <- clean(string),
+         {:ok, tokens, _, _, _, _} <- do_datetime_parse(string),
          naive_datetime <- to_naive_datetime(tokens),
          datetime <- to_datetime(naive_datetime, tokens),
          {:ok, datetime} <- validate_day(datetime),
@@ -100,19 +98,20 @@ defmodule DateTimeParser do
   def parse_datetime(nil, _opts), do: {:error, "Could not parse nil"}
   def parse_datetime(value, _opts), do: {:error, "Could not parse #{value}"}
 
+  def do_datetime_parse(string) do
+    cond do
+      String.contains?(string, "/") -> DateTimeParser.DateTime.parse_us(string)
+      Regex.match?(@epoch_regex, string) -> Epoch.parse(string)
+      true -> DateTimeParser.DateTime.parse(string)
+    end
+  end
+
   @doc """
   Parse `%Time{}` from a string.
   """
   @spec parse_time(String.t() | nil) :: {:ok, Time.t()} | {:error, String.t()}
   def parse_time(string) when is_binary(string) do
-    parser =
-      if Regex.match?(@epoch_regex, string) do
-        &DateTimeParser.Epoch.parse/1
-      else
-        &DateTimeParser.Time.parse/1
-      end
-
-    case string |> clean |> parser.() do
+    case string |> clean() |> do_time_parse() do
       {:ok, tokens, _, _, _, _} ->
         to_time(tokens)
 
@@ -124,19 +123,21 @@ defmodule DateTimeParser do
   def parse_time(nil), do: {:error, "Could not parse nil"}
   def parse_time(value), do: {:error, "Could not parse #{value}"}
 
+  def do_time_parse(string) do
+    if Regex.match?(@epoch_regex, string) do
+      Epoch.parse(string)
+    else
+      DateTimeParser.Time.parse(string)
+    end
+  end
+
   @doc """
   Parse `%Date{}` from a string.
   """
   @spec parse_date(String.t() | nil) :: {:ok, Date.t()} | {:error, String.t()}
   def parse_date(string) when is_binary(string) do
-    parser =
-      cond do
-        String.contains?(string, "/") -> &DateTimeParser.Date.parse_us/1
-        Regex.match?(@epoch_regex, string) -> &DateTimeParser.Epoch.parse/1
-        true -> &DateTimeParser.Date.parse/1
-      end
-
-    with {:ok, tokens, _, _, _, _} <- string |> clean |> parser.(),
+    with string <- clean(string),
+         {:ok, tokens, _, _, _, _} <- do_parse_date(string),
          {:ok, date} <- to_date(tokens),
          {:ok, _} <- validate_day(date) do
       {:ok, date}
@@ -149,89 +150,51 @@ defmodule DateTimeParser do
   def parse_date(nil), do: {:error, "Could not parse nil"}
   def parse_date(value), do: {:error, "Could not parse #{value}"}
 
-  defp from_epoch(tokens) do
-    with {:ok, datetime} <- DateTime.from_unix(tokens[:unix_epoch]) do
-      case tokens[:unix_epoch_subsecond] do
-        nil ->
-          datetime
-
-        subsecond ->
-          truncated_subsecond =
-            subsecond
-            |> Integer.digits()
-            |> Enum.take(6)
-            |> Integer.undigits()
-
-          %{datetime | microsecond: format({:microsecond, truncated_subsecond})}
-      end
+  defp do_parse_date(string) do
+    cond do
+      String.contains?(string, "/") -> DateTimeParser.Date.parse_us(string)
+      Regex.match?(@epoch_regex, string) -> Epoch.parse(string)
+      true -> DateTimeParser.Date.parse(string)
     end
   end
 
   defp to_time(tokens) do
     if tokens[:unix_epoch] do
-      with %Time{} = time <- tokens |> from_epoch() |> DateTime.to_time() do
+      with %Time{} = time <- tokens |> Epoch.from_tokens() |> DateTime.to_time() do
         {:ok, time}
       end
     else
-      Time.new(
-        format_token(tokens, :hour) || 0,
-        format_token(tokens, :minute) || 0,
-        format_token(tokens, :second) || 0,
-        format_token(tokens, :microsecond) || {0, 0}
-      )
+      DateTimeParser.Time.from_tokens(tokens)
     end
   end
 
   defp to_date(tokens) do
     if tokens[:unix_epoch] do
-      with %Date{} = date <- tokens |> from_epoch() |> DateTime.to_date() do
+      with %Date{} = date <- tokens |> Epoch.from_tokens() |> DateTime.to_date() do
         {:ok, date}
       end
     else
-      Date.new(
-        format_token(tokens, :year) || 0,
-        format_token(tokens, :month) || 0,
-        format_token(tokens, :day) || 0
-      )
+      DateTimeParser.Date.from_tokens(tokens)
     end
   end
 
   defp to_naive_datetime(tokens) do
     if tokens[:unix_epoch] do
-      from_epoch(tokens)
+      Epoch.from_tokens(tokens)
     else
-      Map.merge(
-        NaiveDateTime.utc_now(),
-        clean(%{
-          year: format_token(tokens, :year),
-          month: format_token(tokens, :month),
-          day: format_token(tokens, :day),
-          hour: format_token(tokens, :hour) || 0,
-          minute: format_token(tokens, :minute) || 0,
-          second: format_token(tokens, :second) || 0,
-          microsecond: format_token(tokens, :microsecond) || {0, 0}
-        })
-      )
+      DateTimeParser.DateTime.from_tokens(tokens)
     end
   end
 
   defp to_datetime(%DateTime{} = datetime, _tokens), do: datetime
 
-  defp to_datetime(naive_datetime, tokens) do
-    with zone <- format_token(tokens, :zone_abbr),
-         offset <- format_token(tokens, :utc_offset),
-         true <- Enum.any?([zone, offset]),
-         %{} = timezone_info <- Timex.Timezone.get(offset || zone) do
-      naive_datetime
-      |> DateTime.from_naive!("Etc/UTC")
-      |> Map.merge(%{
-        std_offset: timezone_info.offset_std,
-        utc_offset: timezone_info.offset_utc,
-        zone_abbr: timezone_info.abbreviation,
-        time_zone: timezone_info.full_name
-      })
-    else
-      _ -> naive_datetime
+  defp to_datetime(%NaiveDateTime{} = naive_datetime, tokens) do
+    case DateTimeParser.DateTime.timezone_from_tokens(tokens) do
+      %{} = timezone_info ->
+        DateTimeParser.DateTime.from_naive_datetime_and_timezone(naive_datetime, timezone_info)
+
+      _ ->
+        naive_datetime
     end
   end
 
@@ -272,129 +235,4 @@ defmodule DateTimeParser do
       datetime
     end
   end
-
-  defp clean(string) when is_binary(string) do
-    string
-    |> String.trim()
-    |> String.replace(" @ ", "T")
-    |> String.replace(~r{[[:space:]]+}, " ")
-    |> String.replace(" - ", "-")
-    |> String.replace("//", "/")
-    |> String.replace(~r{=|"|'|,|\\}, "")
-    |> String.downcase()
-  end
-
-  defp clean(%{} = map) do
-    map
-    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-    |> Enum.into(%{})
-  end
-
-  defp format_token(tokens, :hour) do
-    case tokens |> find_token(:hour) do
-      {:hour, hour} ->
-        if tokens |> find_token(:am_pm) |> format == "PM" && hour < 12 do
-          hour + 12
-        else
-          hour
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp format_token(tokens, :year) do
-    case tokens |> find_token(:year) |> format() do
-      nil ->
-        nil
-
-      year ->
-        year |> to_4_year() |> String.to_integer()
-    end
-  end
-
-  defp format_token(tokens, token) do
-    tokens |> find_token(token) |> format()
-  end
-
-  defp find_token(tokens, find_me) do
-    Enum.find(tokens, fn
-      {token, _} -> token == find_me
-      _ -> false
-    end)
-  end
-
-  # If the parsed two-digit year is 00 to 49, then
-  #  - If the last two digits of the current year are 00 to 49, then the returned year has the same
-  #    first two digits as the current year.
-  #  - If the last two digits of the current year are 50 to 99, then the first 2 digits of the
-  #    returned year are 1 greater than the first 2 digits of the current year.
-  # If the parsed two-digit year is 50 to 99, then
-  #  - If the last two digits of the current year are 00 to 49, then the first 2 digits of the
-  #    returned year are 1 less than the first 2 digits of the current year.
-  #  - If the last two digits of the current year are 50 to 99, then the returned year has the same
-  #    first two digits as the current year.
-  defp to_4_year(parsed_3yr) when byte_size(parsed_3yr) == 3 do
-    [current_millenia | _rest] =
-      DateTime.utc_now()
-      |> Map.get(:year)
-      |> Integer.digits()
-
-    "#{current_millenia}#{parsed_3yr}"
-  end
-
-  defp to_4_year(parsed_2yr) when byte_size(parsed_2yr) == 2 do
-    [current_millenia, current_century, current_decade, current_year] =
-      DateTime.utc_now()
-      |> Map.get(:year)
-      |> Integer.digits()
-
-    parsed_2yr = String.to_integer(parsed_2yr)
-    current_2yr = String.to_integer("#{current_decade}#{current_year}")
-
-    cond do
-      parsed_2yr < 50 && current_2yr < 50 ->
-        "#{current_millenia}#{current_century}#{parsed_2yr}"
-
-      parsed_2yr < 50 && current_2yr >= 50 ->
-        [_parsed_millenia, parsed_century] =
-          [current_millenia, current_century]
-          |> Integer.undigits()
-          |> Kernel.+(1)
-          |> Integer.digits()
-
-        "#{current_millenia}#{parsed_century}#{parsed_2yr}"
-
-      parsed_2yr >= 50 && current_2yr < 50 ->
-        [parsed_millenia, parsed_century] =
-          [current_millenia, current_century]
-          |> Integer.undigits()
-          |> Kernel.-(1)
-          |> Integer.digits()
-
-        "#{parsed_millenia}#{parsed_century}#{parsed_2yr}"
-
-      parsed_2yr >= 50 && current_2yr >= 50 ->
-        "#{current_millenia}#{current_century}#{parsed_2yr}"
-    end
-  end
-
-  defp to_4_year(parsed_year), do: parsed_year
-
-  defp format({:microsecond, value}) do
-    val = value |> to_string |> String.slice(0, 6)
-    {
-      val |> String.pad_trailing(6, "0") |> String.to_integer(),
-      val |> byte_size()
-    }
-  end
-
-  defp format({:zone_abbr, value}), do: String.upcase(value)
-  defp format({:utc_offset, offset}), do: to_string(offset)
-  defp format({:year, value}), do: to_string(value)
-  defp format({:am_pm, value}), do: String.upcase(value)
-  defp format({_, value}) when is_integer(value), do: value
-  defp format({_, value}), do: String.to_integer(value)
-  defp format(_), do: nil
 end

--- a/lib/epoch.ex
+++ b/lib/epoch.ex
@@ -2,7 +2,26 @@ defmodule DateTimeParser.Epoch do
   @moduledoc false
 
   import NimbleParsec
+  import DateTimeParser.Formatters, only: [format: 1]
   import DateTimeParser.Combinators.Epoch
 
   defparsec(:parse, unix_epoch())
+
+  def from_tokens(tokens) do
+    with {:ok, datetime} <- DateTime.from_unix(tokens[:unix_epoch]) do
+      case tokens[:unix_epoch_subsecond] do
+        nil ->
+          datetime
+
+        subsecond ->
+          truncated_subsecond =
+            subsecond
+            |> Integer.digits()
+            |> Enum.take(6)
+            |> Integer.undigits()
+
+          %{datetime | microsecond: format({:microsecond, truncated_subsecond})}
+      end
+    end
+  end
 end

--- a/lib/formatters.ex
+++ b/lib/formatters.ex
@@ -1,0 +1,128 @@
+defmodule DateTimeParser.Formatters do
+  @moduledoc false
+
+  def format_token(tokens, :hour) do
+    case tokens |> find_token(:hour) do
+      {:hour, hour} ->
+        if tokens |> find_token(:am_pm) |> format == "PM" && hour < 12 do
+          hour + 12
+        else
+          hour
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  def format_token(tokens, :year) do
+    case tokens |> find_token(:year) |> format() do
+      nil ->
+        nil
+
+      year ->
+        year |> to_4_year() |> String.to_integer()
+    end
+  end
+
+  def format_token(tokens, token) do
+    tokens |> find_token(token) |> format()
+  end
+
+  defp find_token(tokens, find_me) do
+    Enum.find(tokens, fn
+      {token, _} -> token == find_me
+      _ -> false
+    end)
+  end
+
+  # If the parsed two-digit year is 00 to 49, then
+  #  - If the last two digits of the current year are 00 to 49, then the returned year has the same
+  #    first two digits as the current year.
+  #  - If the last two digits of the current year are 50 to 99, then the first 2 digits of the
+  #    returned year are 1 greater than the first 2 digits of the current year.
+  # If the parsed two-digit year is 50 to 99, then
+  #  - If the last two digits of the current year are 00 to 49, then the first 2 digits of the
+  #    returned year are 1 less than the first 2 digits of the current year.
+  #  - If the last two digits of the current year are 50 to 99, then the returned year has the same
+  #    first two digits as the current year.
+  defp to_4_year(parsed_3yr) when byte_size(parsed_3yr) == 3 do
+    [current_millenia | _rest] =
+      DateTime.utc_now()
+      |> Map.get(:year)
+      |> Integer.digits()
+
+    "#{current_millenia}#{parsed_3yr}"
+  end
+
+  defp to_4_year(parsed_2yr) when byte_size(parsed_2yr) == 2 do
+    [current_millenia, current_century, current_decade, current_year] =
+      DateTime.utc_now()
+      |> Map.get(:year)
+      |> Integer.digits()
+
+    parsed_2yr = String.to_integer(parsed_2yr)
+    current_2yr = String.to_integer("#{current_decade}#{current_year}")
+
+    cond do
+      parsed_2yr < 50 && current_2yr < 50 ->
+        "#{current_millenia}#{current_century}#{parsed_2yr}"
+
+      parsed_2yr < 50 && current_2yr >= 50 ->
+        [_parsed_millenia, parsed_century] =
+          [current_millenia, current_century]
+          |> Integer.undigits()
+          |> Kernel.+(1)
+          |> Integer.digits()
+
+        "#{current_millenia}#{parsed_century}#{parsed_2yr}"
+
+      parsed_2yr >= 50 && current_2yr < 50 ->
+        [parsed_millenia, parsed_century] =
+          [current_millenia, current_century]
+          |> Integer.undigits()
+          |> Kernel.-(1)
+          |> Integer.digits()
+
+        "#{parsed_millenia}#{parsed_century}#{parsed_2yr}"
+
+      parsed_2yr >= 50 && current_2yr >= 50 ->
+        "#{current_millenia}#{current_century}#{parsed_2yr}"
+    end
+  end
+
+  defp to_4_year(parsed_year), do: parsed_year
+
+  def format({:microsecond, value}) do
+    val = value |> to_string |> String.slice(0, 6)
+    {
+      val |> String.pad_trailing(6, "0") |> String.to_integer(),
+      val |> byte_size()
+    }
+  end
+
+  def format({:zone_abbr, value}), do: String.upcase(value)
+  def format({:utc_offset, offset}), do: to_string(offset)
+  def format({:year, value}), do: to_string(value)
+  def format({:am_pm, value}), do: String.upcase(value)
+  def format({_, value}) when is_integer(value), do: value
+  def format({_, value}), do: String.to_integer(value)
+  def format(_), do: nil
+
+  def clean(string) when is_binary(string) do
+    string
+    |> String.trim()
+    |> String.replace(" @ ", "T")
+    |> String.replace(~r{[[:space:]]+}, " ")
+    |> String.replace(" - ", "-")
+    |> String.replace("//", "/")
+    |> String.replace(~r{=|"|'|,|\\}, "")
+    |> String.downcase()
+  end
+
+  def clean(%{} = map) do
+    map
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Enum.into(%{})
+  end
+end

--- a/lib/time.ex
+++ b/lib/time.ex
@@ -3,6 +3,16 @@ defmodule DateTimeParser.Time do
 
   import NimbleParsec
   import DateTimeParser.Combinators.Time
+  import DateTimeParser.Formatters, only: [format_token: 2]
 
   defparsec(:parse, time())
+
+  def from_tokens(tokens) do
+    Time.new(
+      format_token(tokens, :hour) || 0,
+      format_token(tokens, :minute) || 0,
+      format_token(tokens, :second) || 0,
+      format_token(tokens, :microsecond) || {0, 0}
+    )
+  end
 end


### PR DESCRIPTION
# Why

The main file date_time_parser.ex was getting a bit large and hard to read. This splits up the module.
Also, there's no published roadmap other than what's in my head.

# What 

- Move token formatting into `DateTimeParser.Formatters` module that is imported where needed
- Move functions that convert tokens into a struct into the respective modules.
- Add a roadmap with planned breaking changes, likely to be 1.0
- The token conversion into a `%Date{}` would default to 0 values when not found, but this didn't make sense, nor did it affect parsing. Removing it.
 