### PR TITLE
Do not default to convert DateTime to UTC. Make it opt-in

### DIFF
--- a/lib/date_time_parser.ex
+++ b/lib/date_time_parser.ex
@@ -37,11 +37,10 @@ defmodule DateTimeParser do
     {:ok, DateTime.from_naive!(~N[2018-01-01T15:24:00Z], "Etc/UTC")}
     # or ~U[2018-01-01T15:24:00Z] in Elixir 1.9.0+
 
-    iex> DateTimeParser.parse_datetime(~s|"Dec 1, 2018 7:39:53 AM PST"|)
+    iex> DateTimeParser.parse_datetime(~s|"Dec 1, 2018 7:39:53 AM PST"|, to_utc: true)
     {:ok, DateTime.from_naive!(~N[2018-12-01T14:39:53Z], "Etc/UTC")}
-    # Notice that the date is converted to UTC by default
 
-    iex> {:ok, datetime} = DateTimeParser.parse_datetime(~s|"Dec 1, 2018 7:39:53 AM PST"|, to_utc: false)
+    iex> {:ok, datetime} = DateTimeParser.parse_datetime(~s|"Dec 1, 2018 7:39:53 AM PST"|)
     iex> datetime
     #DateTime<2018-12-01 07:39:53-07:00 PDT PST8PDT>
 
@@ -64,13 +63,16 @@ defmodule DateTimeParser do
 
   Options:
     * `:assume_utc` Default `false`.
-    Only applicable for strings where parsing could not determine a timezone. Instead of returning
-    a NaiveDateTime, this option will assume them to be in UTC timezone, and therefore return a
-    DateTime
+    Only applicable for strings where parsing could not determine a timezone. Instead of returning a
+    NaiveDateTime, this option will assume them to be in UTC timezone, and therefore return a
+    DateTime. If the timezone is determined, then it will continue to be returned in the original
+    timezone. See `to_utc` option to also convert it to UTC.
 
-    * `:to_utc` Default `true`.
-    If there's a timezone detected in the string, then attempt to convert to UTC timezone. This is
-    helpful for storing in databases with Ecto.
+    * `:to_utc` Default `false`.
+    If there's a timezone detected in the string, then attempt to convert to UTC timezone. If you
+    know that your timestamps are in the future and are going to store it for later use, it may be
+    better to _not_ convert to UTC since government organizations may change timezone rules before
+    the timestamp elapses, therefore making the UTC timestamp wrong or invalid.
   """
 
   import DateTimeParser.Formatters
@@ -229,7 +231,7 @@ defmodule DateTimeParser do
   end
 
   defp maybe_convert_to_utc(%DateTime{} = datetime, opts) do
-    if Keyword.get(opts, :to_utc, true) do
+    if Keyword.get(opts, :to_utc, false) do
       Timex.Timezone.convert(datetime, "Etc/UTC")
     else
       datetime

--- a/lib/formatters.ex
+++ b/lib/formatters.ex
@@ -95,6 +95,7 @@ defmodule DateTimeParser.Formatters do
 
   def format({:microsecond, value}) do
     val = value |> to_string |> String.slice(0, 6)
+
     {
       val |> String.pad_trailing(6, "0") |> String.to_integer(),
       val |> byte_size()

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,7 @@ defmodule DateTimeParser.MixProject do
       source_ref: @version,
       extras: [
         "README.md",
+        "pages/Future-UTC-DateTime.md",
         "CHANGELOG.md",
         "EXAMPLES.md",
         "LICENSE.md"

--- a/pages/Future-UTC-DateTime.md
+++ b/pages/Future-UTC-DateTime.md
@@ -1,0 +1,3 @@
+# Future DateTime UTC timestamps
+
+TODO

--- a/pages/Future-UTC-DateTime.md
+++ b/pages/Future-UTC-DateTime.md
@@ -1,3 +1,76 @@
 # Future DateTime UTC timestamps
 
-TODO
+If you are certain that all of your timestamps are in the past, then you can
+safely ignore this guide.
+
+If you are working with timestamps that are in the future, and those timestamps
+are inside countries with governing bodies that have the ability to change
+timezone rules, including daylight savings, then you may want to consider your
+timestamp storage strategy. Shortly, it's not foolproof to convert the timestamp
+to UTC and store only that DateTime.
+
+## Rules Change
+
+Consider this scenario: It's currently year 2019 and you receive a timestamp for
+a user located in Washington, USA for July 4, 2022. You convert it to UTC and
+store it in your database.
+
+Today (in year 2019), Washington state recognizes Daylight Savings Time and it
+shifts back and forth an hour over the year. Since the timestamp is in the
+summer, it's shifted back an hour.
+
+In 2020, Washington enacts a new law that declares that they will no longer be
+participate in Daylight Savings Time and permanently stay in Daylight Savings;
+meaning it's always shifted forward one hour year-round.
+
+You've already stored your timestamps in the future converted to UTC using the
+old rules. How do you know to fix all your timestamps in your database for users
+in Washington state?
+
+## What is our context?
+
+There are 3 elements at play:
+
+1. You need a consistent timestamp field for database queries (opposed to
+   strings). Usually this is UTC timestamps.
+2. The user provided a timestamp based on their location, and looked at the
+   clock on their desk when filling in the form in your web app.
+3. The provided timestamp is based on the location the user is in, and that
+   location follows a set of rules of how time changes throughout the year.
+
+We need to store timestamps in an database column made for timestamps so we can
+achieve #1. This can be more complicated given your database, but using Postgres
+as an example, it internally converts to UTC and queries against that. If you're
+using Ecto as your data mapper, it must always be in UTC before storage.
+
+If the law changes between now and the future timestamp, we've lost the correct
+wall time for the user in #2.
+
+When we immediately convert to UTC, we lose the context in #3.
+
+## Storage Strategy
+
+Store the user's provided timestamp and timezone separately from the converted
+UTC. For example:
+
+```elixir
+field :my_timestamp_utc, :utc_datetime
+field :my_timestamp_tz, :string
+field :my_timestamp_wall, :naive_datetime
+```
+
+Since we're making `my_timestamp_utc` a `:utc_datetime`, we are affirming we
+have the timezone information of UTC. Since we're making `my_timestamp_wall` a
+`:naive_datetime`, we're affirming we do not have the timezone.
+
+Once you have these 3 pieces of context, you can periodically update and verify
+changes. It would be good to update your UTC timestamps whenever your tzdata
+files are updated. If the walltime + timezone is reconverted to UTC and is
+different from your stored UTC timestamp, then you know the rules have changed
+since storage. Update the UTC timestamp and perhaps notify the customer to
+ensure the intentions are still correct (for example, did they already know of
+the upcoming law change and anticipate it?).
+
+## Credits
+
+http://www.creativedeletion.com/2015/03/19/persisting_future_datetimes.html

--- a/test/date_time_parser_test.exs
+++ b/test/date_time_parser_test.exs
@@ -7,10 +7,10 @@ defmodule DateTimeParserTest do
 
   describe "compare with Ruby/Rails datetime parsing" do
     test_datetime_parsing(" 01 Feb 2013", "2013-02-01T00:00:00")
-    test_datetime_parsing(" 03 Jan 2013 10:15:26 -0800", "2013-01-03T18:15:26Z")
+    test_datetime_parsing(" 03 Jan 2013 10:15:26 -0800", "2013-01-03T18:15:26Z", to_utc: true)
     test_datetime_parsing(" 10/1/2018  :: AM", "2018-10-01T00:00:00")
     test_datetime_parsing(" 11 Feb 2013", "2013-02-11T00:00:00")
-    test_datetime_parsing(" 11 Jan 2013 13:26:55 -0800", "2013-01-11T21:26:55Z")
+    test_datetime_parsing(" 11 Jan 2013 13:26:55 -0800", "2013-01-11T21:26:55Z", to_utc: true)
     test_datetime_parsing(" 12/26/2016", "2016-12-26T00:00:00")
     test_datetime_parsing(" 24 Sep 2013", "2013-09-24T00:00:00")
     test_datetime_parsing("01-01-2018", "2018-01-01T00:00:00")
@@ -36,7 +36,7 @@ defmodule DateTimeParserTest do
     test_datetime_parsing("02/21/2018  9:37:42 AM", "2018-02-21T09:37:42")
     test_datetime_parsing("03/5/2018", "2018-03-05T00:00:00")
     test_datetime_parsing("05/01/2018 0:00", "2018-05-01T00:00:00")
-    test_datetime_parsing("06/14/2018 09:42:08 PM-0500", "2018-06-15T02:42:08Z")
+    test_datetime_parsing("06/14/2018 09:42:08 PM-0500", "2018-06-15T02:42:08Z", to_utc: true)
     test_datetime_parsing("06/28/18 1:25", "2018-06-28T01:25:00")
     test_datetime_parsing("1-Apr", "2019-04-01T00:00:00")
     # Ruby parses this next one incorrectly
@@ -54,7 +54,7 @@ defmodule DateTimeParserTest do
     test_datetime_parsing("1/31/2018 0:00:00 UTC", "2018-01-31T00:00:00Z")
     test_datetime_parsing("5/12/2019 12:21:58 PM", "2019-05-12T12:21:58")
     test_datetime_parsing("2011-01-01 04:19:20 -0:00", "2011-01-01T04:19:20Z")
-    test_datetime_parsing("2012-11-23T22:42:25-05:00", "2012-11-24T03:42:25Z")
+    test_datetime_parsing("2012-11-23T22:42:25-05:00", "2012-11-24T03:42:25Z", to_utc: true)
     test_datetime_parsing("2013-12-31T22:18:50+00:00", "2013-12-31T22:18:50Z")
     test_datetime_parsing("10/2/2017 - 23:14", "2017-10-02T23:14:00")
     test_datetime_parsing("10/5/2017 23:52", "2017-10-05T23:52:00")
@@ -65,26 +65,26 @@ defmodule DateTimeParserTest do
     test_datetime_parsing("2013-04-26 11:25:03 UTC", "2013-04-26T11:25:03Z")
     test_datetime_parsing("2013-09-10 22:14:56.717", "2013-09-10T22:14:56.717")
     test_datetime_parsing("2016-11-17 10:36:34.81", "2016-11-17T10:36:34.81")
-    test_datetime_parsing("2015-09-28 10:57:11 -0700", "2015-09-28T17:57:11Z")
+    test_datetime_parsing("2015-09-28 10:57:11 -0700", "2015-09-28T17:57:11Z", to_utc: true)
     test_datetime_parsing("2015/12/1 1:16", "2015-12-01T01:16:00")
     test_datetime_parsing("2016-04-30", "2016-04-30T00:00:00")
     test_datetime_parsing("2016-05-02T01:10:06+00:00", "2016-05-02T01:10:06Z")
     test_datetime_parsing("2016-06-11 15:50:43", "2016-06-11T15:50:43")
     test_datetime_parsing("2016-06-16 06:06:06", "2016-06-16T06:06:06")
     test_datetime_parsing("2016-07-01 01:51:34+00", "2016-07-01T01:51:34Z")
-    test_datetime_parsing("2016-07-31 18:42:46-07:00", "2016-08-01T01:42:46Z")
+    test_datetime_parsing("2016-07-31 18:42:46-07:00", "2016-08-01T01:42:46Z", to_utc: true)
     test_datetime_parsing("2016-08-04T07:00:25Z", "2016-08-04T07:00:25Z")
     test_datetime_parsing("2016-08-19 09:34:51.0", "2016-08-19T09:34:51.0")
     test_datetime_parsing("2016-11-23T16:25:33.971897", "2016-11-23T16:25:33.971897")
     test_datetime_parsing("2016/1/9", "2016-01-09T00:00:00")
     test_datetime_parsing("2017-09-29+00:00", "2017-09-29T00:00:00")
     test_datetime_parsing("2017-10-06+03:45:16", "2017-10-06T03:45:16")
-    test_datetime_parsing("2017-10-24 04:00:10 PDT", "2017-10-24T11:00:10Z")
+    test_datetime_parsing("2017-10-24 04:00:10 PDT", "2017-10-24T11:00:10Z", to_utc: true)
     test_datetime_parsing("2017-12-01 03:52", "2017-12-01T03:52:00")
     test_datetime_parsing("2017/08/08", "2017-08-08T00:00:00")
     test_datetime_parsing("2019/01/31 0:01", "2019-01-31T00:01:00")
     # Ruby gets the time wrong
-    test_datetime_parsing("20190118 949 CST", "2019-01-18T14:49:00Z")
+    test_datetime_parsing("20190118 949 CST", "2019-01-18T14:49:00Z", to_utc: true)
     test_datetime_parsing("29/Aug./2018", "2018-08-29T00:00:00")
     test_datetime_parsing("29/Sep./2018", "2018-09-29T00:00:00")
     test_datetime_parsing("9/10/2018 11:08:13 AM", "2018-09-10T11:08:13")
@@ -92,23 +92,27 @@ defmodule DateTimeParserTest do
     test_datetime_parsing("9/20/2017 18:57:24 UTC", "2017-09-20T18:57:24Z")
     test_datetime_parsing(~s|"=\""10/1/2018\"""|, "2018-10-01T00:00:00")
     test_datetime_parsing(~s|"=\""9/5/2018\"""|, "2018-09-05T00:00:00")
-    test_datetime_parsing(~s|"Apr 1, 2016 12:02:53 AM PDT"|, "2016-04-01T19:02:53Z")
-    test_datetime_parsing(~s|"Apr 1, 2017 2:21:25 AM PDT"|, "2017-04-01T09:21:25Z")
-    test_datetime_parsing(~s|"Dec 1, 2018 7:39:53 AM PST"|, "2018-12-01T14:39:53Z")
+    test_datetime_parsing(~s|"Apr 1, 2016 12:02:53 AM PDT"|, "2016-04-01T19:02:53Z", to_utc: true)
+    test_datetime_parsing(~s|"Apr 1, 2017 2:21:25 AM PDT"|, "2017-04-01T09:21:25Z", to_utc: true)
+    test_datetime_parsing(~s|"Dec 1, 2018 7:39:53 AM PST"|, "2018-12-01T14:39:53Z", to_utc: true)
     test_datetime_parsing("Fri Mar  2 09:01:57 2018", "2018-03-02T09:01:57")
     test_datetime_parsing("Sun Jul  1 00:31:18 2018", "2018-07-01T00:31:18")
     test_datetime_parsing("Fri Mar 31 2017 21:41:40 GMT+0000 (UTC)", "2017-03-31T21:41:40Z")
     test_datetime_parsing("Friday 02 February 2018 10:42:21 AM", "2018-02-02T10:42:21")
-    test_datetime_parsing(~s|"Jan 1, 2013 06:34:31 PM PST"|, "2013-01-02T01:34:31Z")
-    test_datetime_parsing(~s|"Jan 1, 2014 6:44:47 AM PST"|, "2014-01-01T13:44:47Z")
+    test_datetime_parsing(~s|"Jan 1, 2013 06:34:31 PM PST"|, "2013-01-02T01:34:31Z", to_utc: true)
+    test_datetime_parsing(~s|"Jan 1, 2014 6:44:47 AM PST"|, "2014-01-01T13:44:47Z", to_utc: true)
     test_datetime_parsing("Jan-01-19", "2019-01-01T00:00:00")
     test_datetime_parsing("Jan-01-2018", "2018-01-01T00:00:00")
     test_datetime_parsing("Monday 01 October 2018 06:34:19 AM", "2018-10-01T06:34:19")
     test_datetime_parsing("Monday 02 October 2017 9:04:49 AM", "2017-10-02T09:04:49")
-    test_datetime_parsing(~s|"Nov 16, 2017 9:41:28 PM PST"|, "2017-11-17T04:41:28Z")
+    test_datetime_parsing(~s|"Nov 16, 2017 9:41:28 PM PST"|, "2017-11-17T04:41:28Z", to_utc: true)
     # This isn't a valid time with PM specified
     test_datetime_parsing(~s|"Nov 20, 2016 22:09:23 PM"|, "2016-11-20T22:09:23")
-    test_datetime_parsing(~s|"Sat, 29 Sep 2018 21:36:28 -0400"|, "2018-09-30T01:36:28Z")
+
+    test_datetime_parsing(~s|"Sat, 29 Sep 2018 21:36:28 -0400"|, "2018-09-30T01:36:28Z",
+      to_utc: true
+    )
+
     test_datetime_parsing(~s|"September 28, 2016"|, "2016-09-28T00:00:00")
     test_datetime_parsing("Sun Jan 08 2017 04:28:42 GMT+0000 (UTC)", "2017-01-08T04:28:42Z")
     test_datetime_parsing("Sunday 01 January 2017 09:22:46 AM", "2017-01-01T09:22:46")
@@ -206,22 +210,26 @@ defmodule DateTimeParserTest do
 
     test_datetime_parsing(
       "2017-11-04 15:20:47 EDT",
-      DateTime.from_naive!(~N[2017-11-04 19:20:47Z], "Etc/UTC")
+      DateTime.from_naive!(~N[2017-11-04 19:20:47Z], "Etc/UTC"),
+      to_utc: true
     )
 
     test_datetime_parsing(
       "2017-11-04 15:20:47 EST",
-      DateTime.from_naive!(~N[2017-11-04 20:20:47Z], "Etc/UTC")
+      DateTime.from_naive!(~N[2017-11-04 20:20:47Z], "Etc/UTC"),
+      to_utc: true
     )
 
     test_datetime_parsing(
       "2017-11-04 15:20:47-0500",
-      DateTime.from_naive!(~N[2017-11-04 20:20:47Z], "Etc/UTC")
+      DateTime.from_naive!(~N[2017-11-04 20:20:47Z], "Etc/UTC"),
+      to_utc: true
     )
 
     test_datetime_parsing(
       "2017-11-04 15:20:47+0500",
-      DateTime.from_naive!(~N[2017-11-04 10:20:47Z], "Etc/UTC")
+      DateTime.from_naive!(~N[2017-11-04 10:20:47Z], "Etc/UTC"),
+      to_utc: true
     )
 
     test_datetime_parsing(
@@ -231,7 +239,8 @@ defmodule DateTimeParserTest do
 
     test_datetime_parsing(
       "2019-05-20 10:00:00PST",
-      DateTime.from_naive!(~N[2019-05-20 17:00:00Z], "Etc/UTC")
+      DateTime.from_naive!(~N[2019-05-20 17:00:00Z], "Etc/UTC"),
+      to_utc: true
     )
   end
 
@@ -293,11 +302,15 @@ defmodule DateTimeParserTest do
       assert result == DateTime.from_naive!(~N[2019-01-01 00:00:00], "Etc/UTC")
     end
 
-    test "assume_utc: true returns converted DateTime when timezone is determined" do
+    test "assume_utc: true returns timezoned DateTime when timezone is determined" do
       string = "2019-01-01T00:00:00 PST"
       {:ok, result} = DateTimeParser.parse_datetime(string, assume_utc: true)
+      naive_datetime_result = DateTime.to_naive(result)
 
-      assert result == DateTime.from_naive!(~N[2019-01-01 07:00:00], "Etc/UTC")
+      assert naive_datetime_result == ~N[2019-01-01 00:00:00]
+
+      assert %{zone_abbr: "PDT", time_zone: "PST8PDT", utc_offset: -28_800, std_offset: 3600} =
+               result
     end
 
     test "assume_utc: true returns NaiveDateTime when timezone is undetermined" do
@@ -317,14 +330,16 @@ defmodule DateTimeParserTest do
 
     test_datetime_parsing(
       "May 30, 2019 4:31:09 AM PDT",
-      DateTime.from_naive!(~N[2019-05-30 11:31:09], "Etc/UTC")
+      DateTime.from_naive!(~N[2019-05-30 11:31:09], "Etc/UTC"),
+      to_utc: true
     )
 
     test_datetime_parsing("Sep-19-16", ~N[2016-09-19 00:00:00])
 
     test_datetime_parsing(
       "Oct 5, 2018 6:16:56 PM PDT",
-      DateTime.from_naive!(~N[2018-10-06 01:16:56Z], "Etc/UTC")
+      DateTime.from_naive!(~N[2018-10-06 01:16:56Z], "Etc/UTC"),
+      to_utc: true
     )
 
     test_datetime_parsing("19 September 2018 08:15:22 AM", ~N[2018-09-19 08:15:22])


### PR DESCRIPTION
**BREAKING CHANGE**
This is the final of the planned breaking changes.

There is an existing option `to_utc` which was defaulting to `true`. This changes to `false`.
Most of the changes are updating tests and docs.