### PR TITLE
Add bang variants

### DIFF
--- a/lib/date_time_parser.ex
+++ b/lib/date_time_parser.ex
@@ -166,7 +166,7 @@ defmodule DateTimeParser do
 
   @doc """
   Parse a `%DateTime{}`, `%NaiveDateTime{}`, `%Date{}`, or `%Time{}` from a string. Raises a
-  `DateTimeParser.Error` when parsing fails.
+  `DateTimeParser.ParseError` when parsing fails.
 
   Accepts `t:parse_options/0`.
   """
@@ -175,7 +175,7 @@ defmodule DateTimeParser do
   def parse!(string, opts \\ []) do
     case parse(string, opts) do
       {:ok, result} -> result
-      {:error, message} -> raise(__MODULE__.Error, message)
+      {:error, message} -> raise(__MODULE__.ParseError, message)
     end
   end
 
@@ -206,7 +206,7 @@ defmodule DateTimeParser do
   def parse_datetime(value, _opts), do: {:error, "Could not parse #{value}"}
 
   @doc """
-  Parse a `%DateTime{}` or `%NaiveDateTime{}` from a string. Raises a `DateTimeParser.Error` when
+  Parse a `%DateTime{}` or `%NaiveDateTime{}` from a string. Raises a `DateTimeParser.ParseError` when
   parsing fails.
 
   Accepts options `t:parse_datetime_options/0`.
@@ -216,7 +216,7 @@ defmodule DateTimeParser do
   def parse_datetime!(string, opts \\ []) do
     case parse_datetime(string, opts) do
       {:ok, result} -> result
-      {:error, message} -> raise(__MODULE__.Error, message)
+      {:error, message} -> raise(__MODULE__.ParseError, message)
     end
   end
 
@@ -247,13 +247,13 @@ defmodule DateTimeParser do
   def parse_time(value), do: {:error, "Could not parse #{value}"}
 
   @doc """
-  Parse `%Time{}` from a string. Raises a `DateTimeParser.Error` when parsing fails.
+  Parse `%Time{}` from a string. Raises a `DateTimeParser.ParseError` when parsing fails.
   """
   @spec parse_time!(String.t() | nil) :: Time.t() | no_return()
   def parse_time!(string) do
     case parse_time(string) do
       {:ok, result} -> result
-      {:error, message} -> raise(__MODULE__.Error, message)
+      {:error, message} -> raise(__MODULE__.ParseError, message)
     end
   end
 
@@ -298,7 +298,7 @@ defmodule DateTimeParser do
   def parse_date(value, _opts), do: {:error, "Could not parse #{value}"}
 
   @doc """
-  Parse a `%Date{}` from a string. Raises a `DateTimeParser.Error` when parsing fails.
+  Parse a `%Date{}` from a string. Raises a `DateTimeParser.ParseError` when parsing fails.
 
   Accepts options `t:parse_date_options/0`.
   """
@@ -307,7 +307,7 @@ defmodule DateTimeParser do
   def parse_date!(string, opts \\ []) do
     case parse_date(string, opts) do
       {:ok, result} -> result
-      {:error, message} -> raise(__MODULE__.Error, message)
+      {:error, message} -> raise(__MODULE__.ParseError, message)
     end
   end
 

--- a/lib/date_time_parser.ex
+++ b/lib/date_time_parser.ex
@@ -165,8 +165,24 @@ defmodule DateTimeParser do
   end
 
   @doc """
-  Parse a `%DateTime{}` or `%NaiveDateTime{}` from a string. Accepts options
-  `t:parse_datetime_options/0`
+  Parse a `%DateTime{}`, `%NaiveDateTime{}`, `%Date{}`, or `%Time{}` from a string. Raises a
+  `DateTimeParser.Error` when parsing fails.
+
+  Accepts `t:parse_options/0`.
+  """
+  @spec parse!(String.t() | nil, parse_options()) ::
+          DateTime.t() | NaiveDateTime.t() | Date.t() | Time.t() | no_return()
+  def parse!(string, opts \\ []) do
+    case parse(string, opts) do
+      {:ok, result} -> result
+      {:error, message} -> raise(__MODULE__.Error, message)
+    end
+  end
+
+  @doc """
+  Parse a `%DateTime{}` or `%NaiveDateTime{}` from a string.
+
+  Accepts options `t:parse_datetime_options/0`
   """
   @spec parse_datetime(String.t() | nil, parse_datetime_options()) ::
           {:ok, DateTime.t() | NaiveDateTime.t()} | {:error, String.t()}
@@ -188,6 +204,21 @@ defmodule DateTimeParser do
 
   def parse_datetime(nil, _opts), do: {:error, "Could not parse nil"}
   def parse_datetime(value, _opts), do: {:error, "Could not parse #{value}"}
+
+  @doc """
+  Parse a `%DateTime{}` or `%NaiveDateTime{}` from a string. Raises a `DateTimeParser.Error` when
+  parsing fails.
+
+  Accepts options `t:parse_datetime_options/0`.
+  """
+  @spec parse_datetime!(String.t() | nil, parse_datetime_options()) ::
+          DateTime.t() | NaiveDateTime.t() | no_return()
+  def parse_datetime!(string, opts \\ []) do
+    case parse_datetime(string, opts) do
+      {:ok, result} -> result
+      {:error, message} -> raise(__MODULE__.Error, message)
+    end
+  end
 
   defp do_datetime_parse(string) do
     cond do
@@ -215,6 +246,17 @@ defmodule DateTimeParser do
   def parse_time(nil), do: {:error, "Could not parse nil"}
   def parse_time(value), do: {:error, "Could not parse #{value}"}
 
+  @doc """
+  Parse `%Time{}` from a string. Raises a `DateTimeParser.Error` when parsing fails.
+  """
+  @spec parse_time!(String.t() | nil) :: Time.t() | no_return()
+  def parse_time!(string) do
+    case parse_time(string) do
+      {:ok, result} -> result
+      {:error, message} -> raise(__MODULE__.Error, message)
+    end
+  end
+
   defp do_time_parse(string) do
     cond do
       Regex.match?(@epoch_regex, string) ->
@@ -232,7 +274,9 @@ defmodule DateTimeParser do
   end
 
   @doc """
-  Parse `%Date{}` from a string. Accepts options `t:parse_date_options/0`
+  Parse `%Date{}` from a string.
+
+  Accepts options `t:parse_date_options/0`
   """
   @spec parse_date(String.t() | nil, parse_date_options()) ::
           {:ok, Date.t()} | {:error, String.t()}
@@ -252,6 +296,20 @@ defmodule DateTimeParser do
 
   def parse_date(nil, _opts), do: {:error, "Could not parse nil"}
   def parse_date(value, _opts), do: {:error, "Could not parse #{value}"}
+
+  @doc """
+  Parse a `%Date{}` from a string. Raises a `DateTimeParser.Error` when parsing fails.
+
+  Accepts options `t:parse_date_options/0`.
+  """
+  @spec parse_date!(String.t() | nil, parse_datetime_options()) ::
+          Date.t() | no_return()
+  def parse_date!(string, opts \\ []) do
+    case parse_date(string, opts) do
+      {:ok, result} -> result
+      {:error, message} -> raise(__MODULE__.Error, message)
+    end
+  end
 
   defp do_parse_date(string) do
     cond do

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -1,0 +1,5 @@
+defmodule DateTimeParser.Error do
+  @moduledoc "An error when parsing fails"
+
+  defexception [:message]
+end

--- a/lib/parse_error.ex
+++ b/lib/parse_error.ex
@@ -1,4 +1,4 @@
-defmodule DateTimeParser.Error do
+defmodule DateTimeParser.ParseError do
   @moduledoc "An error when parsing fails"
 
   defexception [:message]

--- a/test/date_time_parser_test.exs
+++ b/test/date_time_parser_test.exs
@@ -412,6 +412,52 @@ defmodule DateTimeParserTest do
     test_time_parsing("-45103.1454398148", ~T[20:30:34])
   end
 
+  describe "bang variants" do
+    test "parse! successfully returns results" do
+      assert %NaiveDateTime{} = DateTimeParser.parse!("2019-01-01T01:01:01")
+      assert %DateTime{} = DateTimeParser.parse!("2019-01-01T01:01:01Z")
+      assert %Date{} = DateTimeParser.parse!("2019-01-01")
+      assert %Time{} = DateTimeParser.parse!("9:30pm")
+    end
+
+    test "parse! raises an error when fails to parse" do
+      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+        DateTimeParser.parse!("foo")
+      end
+    end
+
+    test "parse_datetime! successfully returns results" do
+      assert %NaiveDateTime{} = DateTimeParser.parse_datetime!("2019-01-01T01:01:01")
+      assert %DateTime{} = DateTimeParser.parse_datetime!("2019-01-01T01:01:01Z")
+    end
+
+    test "parse_datetime! raises an error when fails to parse" do
+      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+        DateTimeParser.parse_datetime!("foo")
+      end
+    end
+
+    test "parse_date! successfully returns results" do
+      assert %Date{} = DateTimeParser.parse_date!("2019-01-01")
+    end
+
+    test "parse_date! raises an error when fails to parse" do
+      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+        DateTimeParser.parse_date!("foo")
+      end
+    end
+
+    test "parse_time! successfully returns results" do
+      assert %Time{} = DateTimeParser.parse_time!("10:30pm")
+    end
+
+    test "parse_time! raises an error when fails to parse" do
+      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+        DateTimeParser.parse_time!("foo")
+      end
+    end
+  end
+
   describe "errors" do
     test "returns an error when not recognized" do
       assert DateTimeParser.parse_datetime("2017-24-32 16:09:53 UTC") ==

--- a/test/date_time_parser_test.exs
+++ b/test/date_time_parser_test.exs
@@ -421,7 +421,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse! raises an error when fails to parse" do
-      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
         DateTimeParser.parse!("foo")
       end
     end
@@ -432,7 +432,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse_datetime! raises an error when fails to parse" do
-      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
         DateTimeParser.parse_datetime!("foo")
       end
     end
@@ -442,7 +442,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse_date! raises an error when fails to parse" do
-      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
         DateTimeParser.parse_date!("foo")
       end
     end
@@ -452,7 +452,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse_time! raises an error when fails to parse" do
-      assert_raise DateTimeParser.Error, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
         DateTimeParser.parse_time!("foo")
       end
     end


### PR DESCRIPTION
This adds bang variants of the parse functions, 
* `parse!`
* `parse_datetime!`
* `parse_date!`
* `parse_time!`

When parsing fails, it will raise a `DateTimeParser.ParseError` with the `message` key populated.