### PR TITLE
Better error handling

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -63,8 +63,8 @@
 |`01-01-2018`|`2018-01-01`|parse| |
 |`01-Feb-18`|`2018-02-01`|parse| |
 |`01-Jul`|`2019-07-01`|parse|`[assume_date: ~D[2019-01-05]]`|
-|`01-Jul`|`Could not parse 01-Jul`|parse| |
-|`01-Jul`|`Could not parse 01-Jul`|parse_datetime| |
+|`01-Jul`|`Could not parse "01-Jul"`|parse| |
+|`01-Jul`|`Could not parse "01-Jul"`|parse_datetime| |
 |`01-Jul-18`|`2018-07-01`|parse| |
 |`01.09.2018`|`2018-09-01`|parse| |
 |`01.11.2018`|`2018-11-01`|parse| |
@@ -94,7 +94,7 @@
 |`07:09.3`|`07:09:00`|parse_time| |
 |`08:53.0`|`08:53:00`|parse_time| |
 |`1-Apr`|`2019-04-01`|parse|`[assume_date: ~D[2019-01-13]]`|
-|`1-Apr`|`Could not parse 1-Apr`|parse| |
+|`1-Apr`|`Could not parse "1-Apr"`|parse| |
 |`1//1/17`|`2017-01-01`|parse| |
 |`1/1/0117`|`0117-01-01`|parse| |
 |`1/1/17 19:12`|`2017-01-01T19:12:00`|parse| |
@@ -153,15 +153,15 @@
 |`2016-11-17 10:36:34.81`|`2016-11-17T10:36:34.81`|parse| |
 |`2016-11-23T16:25:33.971897`|`2016-11-23T16:25:33.971897`|parse| |
 |`2016/1/9`|`2016-01-09`|parse| |
-|`2017-02-29`|`Could not parse 2017-02-29`|parse_date| |
-|`2017-02-29 00:00:00 UTC`|`Could not parse 2017-02-29 00:00:00 UTC`|parse_datetime| |
-|`2017-04-31`|`Could not parse 2017-04-31`|parse_date| |
-|`2017-04-31 00:00:00 UTC`|`Could not parse 2017-04-31 00:00:00 UTC`|parse_datetime| |
-|`2017-06-31`|`Could not parse 2017-06-31`|parse_date| |
-|`2017-06-31 00:00:00 UTC`|`Could not parse 2017-06-31 00:00:00 UTC`|parse_datetime| |
+|`2017-02-29`|`Could not parse "2017-02-29"`|parse_date| |
+|`2017-02-29 00:00:00 UTC`|`Could not parse "2017-02-29 00:00:00 UTC"`|parse_datetime| |
+|`2017-04-31`|`Could not parse "2017-04-31"`|parse_date| |
+|`2017-04-31 00:00:00 UTC`|`Could not parse "2017-04-31 00:00:00 UTC"`|parse_datetime| |
+|`2017-06-31`|`Could not parse "2017-06-31"`|parse_date| |
+|`2017-06-31 00:00:00 UTC`|`Could not parse "2017-06-31 00:00:00 UTC"`|parse_datetime| |
 |`2017-09-29+00:00`|`2017-09-29T00:00:00`|parse| |
-|`2017-09-31`|`Could not parse 2017-09-31`|parse_date| |
-|`2017-09-31 00:00:00 UTC`|`Could not parse 2017-09-31 00:00:00 UTC`|parse_datetime| |
+|`2017-09-31`|`Could not parse "2017-09-31"`|parse_date| |
+|`2017-09-31 00:00:00 UTC`|`Could not parse "2017-09-31 00:00:00 UTC"`|parse_datetime| |
 |`2017-10-06+03:45:16`|`2017-10-06T03:45:16`|parse| |
 |`2017-10-24 04:00:10 PDT`|`2017-10-24T11:00:10Z`|parse|`[to_utc: true]`|
 |`2017-11-04 15:20:47 EDT`|`2017-11-04`|parse_date| |
@@ -176,8 +176,8 @@
 |`2017-11-04 15:20:47+0500`|`2017-11-04T10:20:47Z`|parse_datetime|`[to_utc: true]`|
 |`2017-11-04 15:20:47-0500`|`2017-11-04`|parse_date| |
 |`2017-11-04 15:20:47-0500`|`2017-11-04T20:20:47Z`|parse_datetime|`[to_utc: true]`|
-|`2017-11-31`|`Could not parse 2017-11-31`|parse_date| |
-|`2017-11-31 00:00:00 UTC`|`Could not parse 2017-11-31 00:00:00 UTC`|parse_datetime| |
+|`2017-11-31`|`Could not parse "2017-11-31"`|parse_date| |
+|`2017-11-31 00:00:00 UTC`|`Could not parse "2017-11-31 00:00:00 UTC"`|parse_datetime| |
 |`2017-12-01 03:52`|`2017-12-01T03:52:00`|parse| |
 |`2017/08/08`|`2017-08-08`|parse| |
 |`2019-05-16+04:00`|`2019-05-16`|parse_date| |

--- a/lib/date_time_parser.ex
+++ b/lib/date_time_parser.ex
@@ -167,12 +167,16 @@ defmodule DateTimeParser do
   """
   @spec parse(String.t() | nil, parse_options()) ::
           {:ok, DateTime.t() | NaiveDateTime.t() | Date.t() | Time.t()} | {:error, String.t()}
-  def parse(string, opts \\ []) do
+  def parse(string, opts \\ [])
+
+  def parse(string, opts) when is_binary(string) do
     with {:error, _} <- parse_datetime(string, opts),
          {:error, _} <- parse_date(string, opts) do
       parse_time(string)
     end
   end
+
+  def parse(value, _opts), do: {:error, "Could not parse #{inspect(value)}"}
 
   @doc """
   Parse a `%DateTime{}`, `%NaiveDateTime{}`, `%Date{}`, or `%Time{}` from a string. Raises a
@@ -208,12 +212,11 @@ defmodule DateTimeParser do
       {:ok, datetime}
     else
       _ ->
-        {:error, "Could not parse #{string}"}
+        {:error, "Could not parse #{inspect(string)}"}
     end
   end
 
-  def parse_datetime(nil, _opts), do: {:error, "Could not parse nil"}
-  def parse_datetime(value, _opts), do: {:error, "Could not parse #{value}"}
+  def parse_datetime(value, _opts), do: {:error, "Could not parse #{inspect(value)}"}
 
   @doc """
   Parse a `%DateTime{}` or `%NaiveDateTime{}` from a string. Raises a `DateTimeParser.ParseError` when
@@ -256,12 +259,11 @@ defmodule DateTimeParser do
         to_time(tokens)
 
       _ ->
-        {:error, "Could not parse #{string}"}
+        {:error, "Could not parse #{inspect(string)}"}
     end
   end
 
-  def parse_time(nil), do: {:error, "Could not parse nil"}
-  def parse_time(value), do: {:error, "Could not parse #{value}"}
+  def parse_time(value), do: {:error, "Could not parse #{inspect(value)}"}
 
   @doc """
   Parse `%Time{}` from a string. Raises a `DateTimeParser.ParseError` when parsing fails.
@@ -307,12 +309,11 @@ defmodule DateTimeParser do
       {:ok, date}
     else
       _ ->
-        {:error, "Could not parse #{string}"}
+        {:error, "Could not parse #{inspect(string)}"}
     end
   end
 
-  def parse_date(nil, _opts), do: {:error, "Could not parse nil"}
-  def parse_date(value, _opts), do: {:error, "Could not parse #{value}"}
+  def parse_date(value, _opts), do: {:error, "Could not parse #{inspect(value)}"}
 
   @doc """
   Parse a `%Date{}` from a string. Raises a `DateTimeParser.ParseError` when parsing fails.

--- a/test/date_time_parser_test.exs
+++ b/test/date_time_parser_test.exs
@@ -498,7 +498,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse! raises an error when fails to parse" do
-      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, ~s|Could not parse "foo"|, fn ->
         DateTimeParser.parse!("foo")
       end
     end
@@ -509,7 +509,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse_datetime! raises an error when fails to parse" do
-      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, ~s|Could not parse "foo"|, fn ->
         DateTimeParser.parse_datetime!("foo")
       end
     end
@@ -519,7 +519,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse_date! raises an error when fails to parse" do
-      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, ~s|Could not parse "foo"|, fn ->
         DateTimeParser.parse_date!("foo")
       end
     end
@@ -529,7 +529,7 @@ defmodule DateTimeParserTest do
     end
 
     test "parse_time! raises an error when fails to parse" do
-      assert_raise DateTimeParser.ParseError, "Could not parse foo", fn ->
+      assert_raise DateTimeParser.ParseError, ~s|Could not parse "foo"|, fn ->
         DateTimeParser.parse_time!("foo")
       end
     end
@@ -538,14 +538,22 @@ defmodule DateTimeParserTest do
   describe "errors" do
     test "returns an error when not recognized" do
       assert DateTimeParser.parse_datetime("2017-24-32 16:09:53 UTC") ==
-               {:error, "Could not parse 2017-24-32 16:09:53 UTC"}
+               {:error, ~s|Could not parse "2017-24-32 16:09:53 UTC"|}
 
       assert DateTimeParser.parse_datetime(nil) == {:error, "Could not parse nil"}
       assert DateTimeParser.parse_date(nil) == {:error, "Could not parse nil"}
       assert DateTimeParser.parse_time(nil) == {:error, "Could not parse nil"}
+      assert DateTimeParser.parse(nil) == {:error, "Could not parse nil"}
+
+      assert DateTimeParser.parse({:ok, "foo"}) == {:error, ~s|Could not parse {:ok, "foo"}|}
+      assert DateTimeParser.parse_date({:ok, "foo"}) == {:error, ~s|Could not parse {:ok, "foo"}|}
+      assert DateTimeParser.parse_time({:ok, "foo"}) == {:error, ~s|Could not parse {:ok, "foo"}|}
+
+      assert DateTimeParser.parse_datetime({:ok, "foo"}) ==
+               {:error, ~s|Could not parse {:ok, "foo"}|}
     end
 
-    test_error("01-Jul", "Could not parse 01-Jul")
+    test_error("01-Jul", ~s|Could not parse "01-Jul"|)
     test_datetime_error("01-Jul")
     test_datetime_error("2017-02-29 00:00:00 UTC")
     test_date_error("2017-02-29")
@@ -555,10 +563,10 @@ defmodule DateTimeParserTest do
 
       test_datetime_error(
         "2017-#{@month}-31 00:00:00 UTC",
-        "Could not parse 2017-#{@month}-31 00:00:00 UTC"
+        ~s|Could not parse "2017-#{@month}-31 00:00:00 UTC"|
       )
 
-      test_date_error("2017-#{@month}-31", "Could not parse 2017-#{@month}-31")
+      test_date_error("2017-#{@month}-31", ~s|Could not parse "2017-#{@month}-31"|)
     end
   end
 end


### PR DESCRIPTION
Thanks to @jakeprem [for pointing this out](https://github.com/taxjar/date_time_parser/pull/29#discussion_r374858821)

This updates our error messages to `#{inspect value}` instead of `#{value}` so it can handle passed-in values that don't implement String.Chars.